### PR TITLE
chore: use jest --env=node for a more accurate comparison

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -7,7 +7,7 @@ const PAD = reset().dim('    ||  ');
 
 const runners = {
 	ava: [require.resolve('ava/cli.js'), 'suites/ava/**'],
-	jest: [require.resolve('jest/bin/jest.js'), 'suites/jest'],
+	jest: [require.resolve('jest/bin/jest.js'), 'suites/jest', '--env=node'],
 	mocha: [require.resolve('mocha/bin/mocha'), 'suites/mocha'],
 	tape: [require.resolve('tape/bin/tape'), 'suites/tape'],
 	uvu: [require.resolve('uvu/bin.js'), 'suites/uvu'],


### PR DESCRIPTION
## Description

- Jest uses JSDOM by default whereas the others don't
  - also edits to the readme are based on my personal machine, where
    _all_ of the tests run slower, it would probably be faster on yours

- There's probably other optimizations to be made here as Jest is
  focused on usability out-of-the-box as opposed to being the most
  performant out-of-the-box
  - e.g. both AVA and Jest transpile code by default

- But a more faithful comparison should also take an average over
  hundreds of runs, post-cache, and should use a large test suite, so
  there's other problems with these benchmarks too
  - this is just me making it a little bit closer with an optimization
    I'm quite familiar with and instantly recognized was missing

## Review Notes

Not trying to start a flame war about proper benchmarks, but figured I'd at least make the tiny optimization that I've used a number of times myself.

## Example

Here's an example run from my machine for this:
```bash
$ node index.js 
~> "ava" took 648ms
    ||  
    ||  
    ||    ✔ sum
    ||    ✔ div
    ||    ✔ mod
    ||    ─
    ||  
    ||    3 tests passed
    ||  
~> "jest" took 915ms
    ||  
    ||  PASS suites/jest/index.spec.js
    ||    sum
    ||      ✓ should be a function (2 ms)
    ||      ✓ should compute values correctly (1 ms)
    ||    div
    ||      ✓ should be a function
    ||      ✓ should compute values correctly (1 ms)
    ||    mod
    ||      ✓ should be a function
    ||      ✓ should compute values correctly (1 ms)
    ||  
    ||  Test Suites: 1 passed, 1 total
    ||  Tests:       6 passed, 6 total
    ||  Snapshots:   0 total
    ||  Time:        0.359 s, estimated 1 s
    ||  Ran all test suites matching /suites\/jest/i.
    ||  
~> "mocha" took 237ms
    ||  
    ||  
    ||  
    ||    sum
    ||      ✓ should be a function
    ||      ✓ should compute result correctly
    ||  
    ||    div
    ||      ✓ should be a function
    ||      ✓ should compute result correctly
    ||  
    ||    mod
    ||      ✓ should be a function
    ||      ✓ should compute result correctly
    ||  
    ||  
    ||    6 passing (5ms)
    ||  
    ||  
~> "tape" took 123ms
    ||  
    ||  TAP version 13
    ||  # sum
    ||  ok 1 should be strictly equal
    ||  ok 2 should be strictly equal
    ||  ok 3 should be strictly equal
    ||  ok 4 should be strictly equal
    ||  # div
    ||  ok 5 should be strictly equal
    ||  ok 6 should be strictly equal
    ||  ok 7 should be strictly equal
    ||  ok 8 should be strictly equal
    ||  # mod
    ||  ok 9 should be strictly equal
    ||  ok 10 should be strictly equal
    ||  ok 11 should be strictly equal
    ||  ok 12 should be strictly equal
    ||  
    ||  1..12
    ||  # tests 12
    ||  # pass  12
    ||  
    ||  # ok
    ||  
    ||  
~> "uvu" took 96ms
    ||  
    ||  index.js
    ||  • • •   (3 / 3)
    ||  
    ||    Total:     3
    ||    Passed:    3
    ||    Skipped:   0
    ||    Duration:  1.80ms
    ||  
    ||  
```

You can see that all of them are slower on my machine, so for a closer comparison should also re-run a number of times on your machine.