### PR TITLE
Add `uvu/spy` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /assert
 /parse
 /diff
+/spy

--- a/docs/api.spy.md
+++ b/docs/api.spy.md
@@ -1,0 +1,27 @@
+# `uvu/spy`
+
+The `uvu/spy` module contains functions to spy on function calls and their arguments. You can use it to verify if a callback function is correctly invoked with the expected arguments.
+
+```js
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { spy } from 'uvu/spy';
+
+test('check if function is called twice', () => {
+  const testFunction = spy((a, b) => a + b);
+
+  add(1, 2);
+  add(3, 4);
+
+  // Check if called twice
+  assert.is(testFunction.calls.length, 2);
+
+  // Check return value of 1st call
+  assert.is(testFunction.calls[0].return, 3);
+
+  // Check arguments of 2nd call
+  assert.equal(testFunction.calls[1].args, [3, 4]);
+});
+
+test.run();
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,3 +104,11 @@ declare module 'uvu/parse' {
 	function parse(dir: string, pattern: string, opts?: Partial<Options>): Promise<Argv>;
 	export = parse;
 }
+
+declare module 'uvu/spy' {
+	interface Spy<T extends any[], R> {
+		(...args: T): R;
+		calls: Array<{ args: T, return: R }>;
+	}
+	function spy<T extends any[], R>(fn: (...args: T) => R): Spy<T, R>;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "./parse": {
       "require": "./parse/index.js",
       "import": "./parse/index.mjs"
+    },
+    "./spy": {
+      "require": "./spy/index.js",
+      "import": "./spy/index.mjs"
     }
   },
   "files": [
@@ -34,12 +38,14 @@
     "assert",
     "parse",
     "diff",
-    "dist"
+    "dist",
+    "spy"
   ],
   "modes": {
     "diff": "src/diff.js",
     "parse": "src/parse.js",
     "assert": "src/assert.js",
+    "spy": "src/spy.js",
     "default": "src/index.js"
   },
   "scripts": {
@@ -71,6 +77,7 @@
   "_moduleAliases": {
     "uvu": "src/index.js",
     "uvu/diff": "src/diff.js",
-    "uvu/assert": "src/assert.js"
+    "uvu/assert": "src/assert.js",
+    "uvu/spy": "src/spy.js"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@
 * Supports native ES Modules
 * Browser-Compatible
 * Familiar API
+* Function Spies
 
 
 ## Install
@@ -109,6 +110,11 @@ A collection of assertion methods to use within your tests. Please note that:
 * these are browser compatible
 * these are _completely_ optional
 
+### Module: `uvu/spy`
+
+> [View `uvu/spy` API documentation](/docs/api.spy.md)
+
+Functions to spy on functions to assert how often and with wich arguments they were called.
 
 ## Benchmarks
 

--- a/src/spy.js
+++ b/src/spy.js
@@ -1,0 +1,20 @@
+export function spy(cb) {
+	const calls = [];
+	const wrapped = function(...args) {
+		const call = { args, return: undefined };
+		calls.push(call);
+		const res = cb.apply(this, args)
+
+		if (res && typeof res.then === "function") {
+			return res.then(r => {
+				call.return = r;
+				return r;
+			})
+		}
+
+		call.return = res;
+		return res;
+	};
+	wrapped.calls = calls;
+	return wrapped;
+}

--- a/test/spy.js
+++ b/test/spy.js
@@ -1,0 +1,33 @@
+import * as assert from "uvu/assert";
+import { suite } from "uvu";
+import { spy } from "uvu/spy"
+
+const spies = suite('spies')
+
+spies('should call original function', () => {
+	const fn = spy((a, b) => a + b);
+	assert.is(fn(1, 2), 3);
+	assert.equal(fn.calls, [{ args: [1, 2], return: 3 }]);
+
+	fn(3, 4);
+	assert.is(fn.calls.length, 2);
+	assert.equal(fn.calls[0], { args: [1, 2], return: 3 });
+	assert.equal(fn.calls[1], { args: [3, 4], return: 7 });
+});
+
+spies('should forward "this" value', () => {
+	const fn = spy(function foo() {
+		return this;
+	});
+	assert.is(fn.call("foo"), "foo");
+});
+
+spies('should work with Promises', async () => {
+	const fn = spy(async x => Promise.resolve().then(() => x));
+	const res = await fn('foo');
+
+	assert.is(res, 'foo');
+	assert.equal(fn.calls, [{ args: ['foo'], return: 'foo'}]);
+});
+
+spies.run()


### PR DESCRIPTION
This PR adds a new `uvu/spy` package that exports a function to spy on function calls. This works with both sync and async functions. All function arguments, return values and the proper `this` context is captured and can be asserted against.

Example:

```js
import { test } from 'uvu';
import * as assert from 'uvu/assert';
import { spy } from 'uvu/spy';

test('check if function is called twice', () => {
  const testFunction = spy((a, b) => a + b);

  add(1, 2);
  add(3, 4);

  // Check if called twice
  assert.is(testFunction.calls.length, 2);

  // Check return value of 1st call
  assert.is(testFunction.calls[0].return, 3);

  // Check arguments of 2nd call
  assert.equal(testFunction.calls[1].args, [3, 4]);
});
```

Fixes #10 .