### PR TITLE
Made `operator` property on errors optional.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,11 +46,11 @@ function stack(stack, idx) {
 }
 
 function format(name, err, suite = '') {
-	let details = err.details;
+	let { details, operator='' } = err;
 	let idx = err.stack && err.stack.indexOf('\n');
-	if (err.name.startsWith('AssertionError') && !err.operator.includes('not')) details = compare(err.actual, err.expected); // TODO?
+	if (err.name.startsWith('AssertionError') && !operator.includes('not')) details = compare(err.actual, err.expected); // TODO?
 	let str = '  ' + FAILURE + (suite ? kleur.red(SUITE(` ${suite} `)) : '') + ' ' + QUOTE + kleur.red().bold(name) + QUOTE;
-	str += '\n    ' + err.message + kleur.italic().dim(`  (${err.operator})`) + '\n';
+	str += '\n    ' + err.message + (operator ? kleur.italic().dim(`  (${operator})`) : '') + '\n';
 	if (details) str += GUTTER + details.split('\n').join(GUTTER);
 	if (!!~idx) str += stack(err.stack, idx);
 	return str + '\n';


### PR DESCRIPTION
If I just do inside a test:
```javascript
throw Error("Mesage");
```
I get this:
```
Message  (undefined)
```
Followed by the stack trace, instead of just getting `Message`. This is because the format function is expecting the error to have a string property `operator` to put after the message of the error.

This MR makes it so if that property is missing, we just skip it.