### PR TITLE
fix(diff): retain `undefined` and `NaN` in output

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
-type Arrayable<T> = T[] | T;
-type Promisable<T> = Promise<T> | T;
-
 declare namespace uvu {
+	type Arrayable<T> = T[] | T;
+	type Promisable<T> = Promise<T> | T;
+
 	type Callback<T> = (context: T) => Promisable<void>;
 
 	interface Hook<T> {
@@ -95,8 +95,8 @@ declare module 'uvu/parse' {
 
 	interface Options {
 		cwd: string;
-		require: Arrayable<string>;
-		ignore: Arrayable<string | RegExp>;
+		require: uvu.Arrayable<string>;
+		ignore: uvu.Arrayable<string | RegExp>;
 	}
 
 	interface Argv {

--- a/src/diff.js
+++ b/src/diff.js
@@ -179,10 +179,16 @@ export function sort(input, expect) {
 export function circular() {
 	var cache = new Set;
 	return function print(key, val) {
+		if (val === void 0) return '[__VOID__]';
+		if (typeof val === 'number' && val !== val) return '[__NAN__]';
 		if (!val || typeof val !== 'object') return val;
 		if (cache.has(val)) return '[Circular]';
 		cache.add(val); return val;
 	}
+}
+
+export function stringify(input) {
+	return JSON.stringify(input, circular(), 2).replace(/"\[__NAN__\]"/g, 'NaN').replace(/"\[__VOID__\]"/g, 'undefined');
 }
 
 export function compare(input, expect) {
@@ -190,8 +196,8 @@ export function compare(input, expect) {
 	if (expect instanceof RegExp) return chars(''+input, ''+expect);
 
 	if (expect && typeof expect == 'object') {
-		input = JSON.stringify(sort(input, expect), circular(), 2);
-		expect = JSON.stringify(expect, circular(), 2);
+		input = stringify(sort(input, expect));
+		expect = stringify(expect);
 	}
 
 	let isA = typeof input == 'string';

--- a/test/diff.js
+++ b/test/diff.js
@@ -698,6 +698,31 @@ compare('should proxy `$.lines` for Object inputs', () => {
 		'++··"foo":·1\n' +
 		'··}\n'
 	);
+
+	assert.is(
+		strip($.compare({ foo: 2, bar: undefined, baz: NaN }, { foo: 1, bar: null })),
+		'··{\n' +
+		'Actual:\n' +
+		'--··"foo":·2,\n' +
+		'--··"bar":·undefined,\n' +
+		'--··"baz":·NaN\n' +
+		'Expected:\n' +
+		'++··"foo":·1,\n' +
+		'++··"bar":·null\n' +
+		'··}\n'
+	);
+
+	assert.is(
+		strip($.compare({ foo: 2, bar: null, baz: NaN }, { foo: 2, bar: undefined, baz: NaN })),
+		'··{\n' +
+		'····"foo":·2,\n' +
+		'Actual:\n' +
+		'--··"bar":·null,\n' +
+		'Expected:\n' +
+		'++··"bar":·undefined,\n' +
+		'····"baz":·NaN\n' +
+		'··}\n'
+	);
 });
 
 compare('should proxy `$.lines` for multi-line String inputs', () => {
@@ -725,6 +750,18 @@ compare('should proxy `$.direct` for Number inputs', () => {
 		strip($.compare(123, 12345)),
 		'++12345    (Expected)\n' +
 		'--123      (Actual)\n'
+	);
+
+	assert.snapshot(
+		strip($.compare(123, NaN)),
+		'++NaN    (Expected)\n' +
+		'--123    (Actual)\n'
+	);
+
+	assert.snapshot(
+		strip($.compare(NaN, 123)),
+		'++123    (Expected)\n' +
+		'--NaN    (Actual)\n'
 	);
 });
 
@@ -770,6 +807,18 @@ compare('should handle string against non-type mismatch', () => {
 	assert.snapshot(
 		strip($.compare(undefined, 'foobar')),
 		'++foobar     [string]     (Expected)\n' +
+		'--undefined  [undefined]  (Actual)\n'
+	);
+
+	assert.snapshot(
+		strip($.compare(NaN, undefined)),
+		'++undefined  [undefined]  (Expected)\n' +
+		'--NaN        [number]     (Actual)\n'
+	);
+
+	assert.snapshot(
+		strip($.compare(undefined, NaN)),
+		'++NaN        [number]     (Expected)\n' +
 		'--undefined  [undefined]  (Actual)\n'
 	);
 });

--- a/test/diff.js
+++ b/test/diff.js
@@ -1001,3 +1001,33 @@ circular('should replace circular references with "[Circular]" :: Array', () => 
 });
 
 circular.run();
+
+// ---
+
+const stringify = suite('stringify');
+
+stringify('should wrap `JSON.stringify` native', () => {
+	const input = { a:1, b:2, c:'c', d:null, e:()=>{} };
+
+	assert.is(
+		$.stringify(input),
+		JSON.stringify(input, null, 2)
+	);
+});
+
+stringify('should retain `undefined` and `NaN` values :: Object', () => {
+	assert.is(
+		$.stringify({ a: 1, b: undefined, c: NaN }),
+		'{\n  "a": 1,\n  "b": undefined,\n  "c": NaN\n}'
+	);
+});
+
+// In ES6, array holes are treated like `undefined` values
+stringify('should retain `undefined` and `NaN` values :: Array', () => {
+	assert.is(
+		$.stringify([1, undefined, 2, , 3, NaN, 4, 5]),
+		'[\n  1,\n  undefined,\n  2,\n  undefined,\n  3,\n  NaN,\n  4,\n  5\n]'
+	);
+});
+
+stringify.run();

--- a/test/diff.js
+++ b/test/diff.js
@@ -938,11 +938,25 @@ sort.run();
 const circular = suite('circular');
 
 circular('should ignore non-object values', () => {
-	const input = { a:1, b:2, c:'c', d:null, e:undefined };
+	const input = { a:1, b:2, c:'c', d:null, e:()=>{} };
 
 	assert.is(
 		JSON.stringify(input, $.circular()),
+		'{"a":1,"b":2,"c":"c","d":null}'
+	);
+});
+
+circular('should retain `undefined` and `NaN` values', () => {
+	const input = { a:1, b:undefined, c:NaN };
+
+	assert.is(
+		JSON.stringify(input, $.circular()),
+		'{"a":1,"b":"[__VOID__]","c":"[__NAN__]"}'
+	);
+
+	assert.is(
 		JSON.stringify(input),
+		'{"a":1,"c":null}'
 	);
 });
 


### PR DESCRIPTION
By default, `JSON.stringify` hides `undefined` and `NaN` values. 

This can be _super_ annoying when your assertion fails correctly, but doesn't show you the reason(s) why. Take these comparisons for example:

<img width="400" src="https://user-images.githubusercontent.com/5855893/89703309-3c1c4580-d8fe-11ea-8f6c-874e66b32887.png">

You can see that direct, simple comparisons (via `assert.is`) are fine. But any instances within complex values (object, arrays) were lost. AKA, the `{ foo: NaN }` was _printed_ as `{ foo: null }` -- hence grey text. We see this again with the last assertion with `{ foo: null }` ... and then `{ foo: undefined }` is hidden entirely, leaving an empty `Expected:` block.

After these changes, `undefined` and `NaN` are printed in the diff'ing output so that we have true data representations~!

<img width="280" src="https://user-images.githubusercontent.com/5855893/89703378-ea27ef80-d8fe-11ea-87f3-7e72a2d74e6d.png">

