### PR TITLE
feat: also pass the name of the things to hooks

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace uvu {
-	type Callback<T> = (context: T, breadcrumbs?: string[]) => Promise<void> | void;
+	type Crumbs = { __suite__: string; __test__: string };
+	type Callback<T> = (context: T & Crumbs) => Promise<void> | void;
 
 	interface Hook<T> {
 		(hook: Callback<T>): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace uvu {
-	type Callback<T> = (context: T, name?: string) => Promise<void> | void;
+	type Callback<T> = (context: T, breadcrumbs?: [suiteName?: string, testName?: string, ...crumbs: string[]]) => Promise<void> | void;
 
 	interface Hook<T> {
 		(hook: Callback<T>): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace uvu {
-	type Callback<T> = (context: T) => Promise<void> | void;
+	type Callback<T> = (context: T, name?: string) => Promise<void> | void;
 
 	interface Hook<T> {
 		(hook: Callback<T>): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace uvu {
-	type Callback<T> = (context: T, breadcrumbs?: [suiteName?: string, testName?: string, ...crumbs: string[]]) => Promise<void> | void;
+	type Callback<T> = (context: T, breadcrumbs?: string[]) => Promise<void> | void;
 
 	interface Hook<T> {
 		(hook: Callback<T>): void;

--- a/src/index.js
+++ b/src/index.js
@@ -60,30 +60,30 @@ async function runner(ctx, name) {
 	let { only, tests, before, after, bEach, aEach, state } = ctx;
 	let hook, test, arr = only.length ? only : tests;
 	let num=0, errors='', total=arr.length;
-	let breadcrumbs = name ? [name] : [];
+	let crumbs = name ? [name] : [];
 
 	try {
 		if (name) write(SUITE(kleur.black(` ${name} `)) + ' ');
-		for (hook of before) await hook(state, breadcrumbs);
+		for (hook of before) await hook(state, crumbs);
 
 		for (test of arr) {
-			breadcrumbs.push(test.name);
+			crumbs.push(test.name);
 			try {
-				for (hook of bEach) await hook(state, breadcrumbs);
+				for (hook of bEach) await hook(state, crumbs);
 				await test.handler(state);
-				for (hook of aEach) await hook(state, breadcrumbs);
+				for (hook of aEach) await hook(state, crumbs);
 				write(PASS);
 				num++;
 			} catch (err) {
-				for (hook of aEach) await hook(state, breadcrumbs);
+				for (hook of aEach) await hook(state, crumbs);
 				if (errors.length) errors += '\n';
 				errors += format(test.name, err, name);
 				write(FAIL);
 			}
-			breadcrumbs.pop();
+			crumbs.pop();
 		}
 	} finally {
-		for (hook of after) await hook(state, [name]);
+		for (hook of after) await hook(state, crumbs);
 		let msg = `  (${num} / ${total})\n`;
 		let skipped = (only.length ? tests.length : 0) + ctx.skips;
 		write(errors.length ? kleur.red(msg) : kleur.green(msg));

--- a/src/index.js
+++ b/src/index.js
@@ -63,24 +63,24 @@ async function runner(ctx, name) {
 
 	try {
 		if (name) write(SUITE(kleur.black(` ${name} `)) + ' ');
-		for (hook of before) await hook(state);
+		for (hook of before) await hook(state, name);
 
 		for (test of arr) {
 			try {
-				for (hook of bEach) await hook(state);
+				for (hook of bEach) await hook(state, `${name} ${test.name}`);
 				await test.handler(state);
-				for (hook of aEach) await hook(state);
+				for (hook of aEach) await hook(state, `${name} ${test.name}`);
 				write(PASS);
 				num++;
 			} catch (err) {
-				for (hook of aEach) await hook(state);
+				for (hook of aEach) await hook(state, `${name} ${test.name}`);
 				if (errors.length) errors += '\n';
 				errors += format(test.name, err, name);
 				write(FAIL);
 			}
 		}
 	} finally {
-		for (hook of after) await hook(state);
+		for (hook of after) await hook(state, name);
 		let msg = `  (${num} / ${total})\n`;
 		let skipped = (only.length ? tests.length : 0) + ctx.skips;
 		write(errors.length ? kleur.red(msg) : kleur.green(msg));

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,8 @@ async function runner(ctx, name) {
 	let num=0, errors='', total=arr.length;
 	let crumbs = name ? [name] : [];
 
+	console.log({ crumbs });
+
 	try {
 		if (name) write(SUITE(kleur.black(` ${name} `)) + ' ');
 		for (hook of before) await hook(state, crumbs);

--- a/test/suite.js
+++ b/test/suite.js
@@ -285,24 +285,38 @@ context3.run();
 
 // ---
 
-const breadcrumbs = suite('breadcrumbs');
-
-breadcrumbs('should receive "breadcrumbs" array', (ctx, crumbs) => {
-	console.log('I GOT', crumbs);
-	assert.instance(crumbs, Array);
+const breadcrumbs = suite('breadcrumbs', {
+	count: 1,
 });
 
-breadcrumbs('should see [suite, test] names', (ctx, crumbs) => {
-	assert.is(crumbs.length, 2);
-	assert.equal(crumbs, ['breadcrumbs', 'should see [suite, test] names']);
+breadcrumbs.before(ctx => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, '');
 });
 
-breadcrumbs('test #3', (ctx, crumbs) => {
-	assert.equal(crumbs, ['breadcrumbs', 'test #3']);
+breadcrumbs.after(ctx => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, '');
 });
 
-breadcrumbs('test #4', (ctx, crumbs) => {
-	assert.equal(crumbs, ['breadcrumbs', 'test #4']);
+breadcrumbs.before.each(ctx => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, `test #${ctx.count}`);
+});
+
+breadcrumbs.after.each(ctx => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, `test #${ctx.count++}`);
+});
+
+breadcrumbs('test #1', (ctx) => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, 'test #1');
+});
+
+breadcrumbs('test #2', (ctx) => {
+	assert.is(ctx.__suite__, 'breadcrumbs');
+	assert.is(ctx.__test__, 'test #2');
 });
 
 breadcrumbs.run();

--- a/test/suite.js
+++ b/test/suite.js
@@ -282,3 +282,27 @@ context3('should allow self-referencing instance(s) within context', ctx => {
 });
 
 context3.run();
+
+// ---
+
+const breadcrumbs = suite('breadcrumbs');
+
+breadcrumbs('should receive "breadcrumbs" array', (ctx, crumbs) => {
+	console.log('I GOT', crumbs);
+	assert.instance(crumbs, Array);
+});
+
+breadcrumbs('should see [suite, test] names', (ctx, crumbs) => {
+	assert.is(crumbs.length, 2);
+	assert.equal(crumbs, ['breadcrumbs', 'should see [suite, test] names']);
+});
+
+breadcrumbs('test #3', (ctx, crumbs) => {
+	assert.equal(crumbs, ['breadcrumbs', 'test #3']);
+});
+
+breadcrumbs('test #4', (ctx, crumbs) => {
+	assert.equal(crumbs, ['breadcrumbs', 'test #4']);
+});
+
+breadcrumbs.run();


### PR DESCRIPTION
This PR aims to also pass through the name of either the suite or the test through to hooks.

This would aid in things like `playwright` and taking a screenshot after every test, and naming it the same as the test.