### PR TITLE
fix: type defs for a `suite` takes a context

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,5 +19,5 @@ declare namespace uvu {
 type Context = Record<string, any>;
 export const test: uvu.Test<Context>;
 export type Callback<T=Context> = uvu.Callback<T>;
-export function suite<T=Context>(title?: string, context?: Partial<T>): uvu.Test<T>;
+export function suite<T=Context>(title?: string, context?: T): uvu.Test<T>;
 export function exec(bail?: boolean): Promise<void>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,5 +19,5 @@ declare namespace uvu {
 type Context = Record<string, any>;
 export const test: uvu.Test<Context>;
 export type Callback<T=Context> = uvu.Callback<T>;
-export function suite<T=Context>(title?: string, suite?: T): uvu.Test<T>;
+export function suite<T=Context>(title?: string, context?: T): uvu.Test<T>;
 export function exec(bail?: boolean): Promise<void>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,5 +19,5 @@ declare namespace uvu {
 type Context = Record<string, any>;
 export const test: uvu.Test<Context>;
 export type Callback<T=Context> = uvu.Callback<T>;
-export function suite<T=Context>(title?: string, context?: T): uvu.Test<T>;
+export function suite<T=Context>(title?: string, context?: Partial<T>): uvu.Test<T>;
 export function exec(bail?: boolean): Promise<void>;


### PR DESCRIPTION
You don't pass a `suite` to the suite method, you pass a `context`. 👀