### PR TITLE
diff: fix empty string handling

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -89,7 +89,7 @@ export function chars(input, expect) {
 
 	if (l1 === l2) {
 		// no length offsets
-	} else if (tmp.removed) {
+	} else if (tmp.removed && arr[i + 1]) {
 		let del = tmp.count - arr[i + 1].count;
 		if (del == 0) {
 			// wash~

--- a/test/diff.js
+++ b/test/diff.js
@@ -547,6 +547,22 @@ chars('should print "→" character for tab', () => {
 	);
 });
 
+chars('should handle empty string', () => {
+	assert.is(
+		strip($.chars('foo bar', '')),
+		'++           (Expected)\n' +
+		'--foo·bar    (Actual)\n' +
+		'  ^^^^^^^'
+		);
+
+	assert.is(
+		strip($.chars('', 'foo bar')),
+		'++foo·bar    (Expected)\n' +
+		'--           (Actual)\n' +
+		'  ^^^^^^^'
+	);
+})
+
 chars.run();
 
 // ---


### PR DESCRIPTION
Currently comparing with an empty strings throws following error:
```
TypeError: Cannot read property 'count' of undefined
    at chars (/..../node_modules/uvu/diff/index.js:95:36)
```