### PR TITLE
Stricter isNode check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[],
 const milli = arr => (arr[0]*1e3 + arr[1]/1e6).toFixed(2) + 'ms';
 const hook = (ctx, key) => handler => ctx[key].push(handler);
 
-if (isNode = typeof process !== 'undefined') {
+if (isNode = typeof process !== 'undefined' && Array.isArray(process.argv)) {
 	// globalThis polyfill; Node < 12
 	if (typeof globalThis !== 'object') {
 		Object.defineProperty(global, 'globalThis', {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[],
 const milli = arr => (arr[0]*1e3 + arr[1]/1e6).toFixed(2) + 'ms';
 const hook = (ctx, key) => handler => ctx[key].push(handler);
 
-if (isNode = typeof process !== 'undefined' && Array.isArray(process.argv)) {
+if (isNode = typeof process < 'u' && typeof process.stdout < 'u') {
 	// globalThis polyfill; Node < 12
 	if (typeof globalThis !== 'object') {
 		Object.defineProperty(global, 'globalThis', {


### PR DESCRIPTION
Hi!

I tried running `uvu` with [vite](https://github.com/vitejs/vite) and because `vite` injects `env` on to `window.process`, `uvu` would fail for me at `process.argv.some()`.

<img width="439" alt="uvu   vite" src="https://user-images.githubusercontent.com/957321/98243346-15f25a00-1f6e-11eb-9372-ab351fcefe2c.png">

Other front end tools also sometimes override `process` so that client code can [grab ENV variables](https://cli.vuejs.org/guide/mode-and-env.html#using-env-variables-in-client-side-code).

Thanks for creating `uvu`, it's great!