### PR TITLE
fix: move `QUEUE` to `globalThis` scope;

### DIFF
--- a/run/index.js
+++ b/run/index.js
@@ -1,11 +1,12 @@
-const { exec, QUEUE } = require('uvu');
+const { exec } = require('uvu');
 
 exports.run = async function (suites, opts={}) {
 	globalThis.UVU_DEFER = 1;
+	globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
 
 	suites.forEach((suite, idx) => {
+		globalThis.UVU_QUEUE.push([suite.name]);
 		globalThis.UVU_INDEX = idx;
-		QUEUE.push([suite.name]);
 		require(suite.file);
 	});
 

--- a/run/index.js
+++ b/run/index.js
@@ -2,7 +2,6 @@ const { exec } = require('uvu');
 
 exports.run = async function (suites, opts={}) {
 	globalThis.UVU_DEFER = 1;
-	globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
 
 	suites.forEach((suite, idx) => {
 		globalThis.UVU_QUEUE.push([suite.name]);

--- a/run/index.mjs
+++ b/run/index.mjs
@@ -3,7 +3,6 @@ import { exec } from 'uvu';
 export async function run(suites, opts={}) {
 	let suite, idx=0;
 	globalThis.UVU_DEFER = 1;
-	globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
 
 	for (suite of suites) {
 		globalThis.UVU_INDEX = idx++;

--- a/run/index.mjs
+++ b/run/index.mjs
@@ -1,12 +1,13 @@
-import { exec, QUEUE } from 'uvu';
+import { exec } from 'uvu';
 
 export async function run(suites, opts={}) {
 	let suite, idx=0;
 	globalThis.UVU_DEFER = 1;
+	globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
 
 	for (suite of suites) {
-		QUEUE.push([suite.name]);
 		globalThis.UVU_INDEX = idx++;
+		globalThis.UVU_QUEUE.push([suite.name]);
 		await import('file:///' + suite.file);
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ if (isNode = typeof process < 'u' && typeof process.stdout < 'u') {
 	hrtime = (now = performance.now()) => () => (performance.now() - now).toFixed(2) + 'ms';
 }
 
+globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
+isCLI || UVU_QUEUE.push([null]);
+
 const QUOTE = kleur.dim('"'), GUTTER = '\n        ';
 const FAIL = kleur.red('✘ '), PASS = kleur.gray('• ');
 const IGNORE = /^\s*at.*(?:\(|\s)(?:node|(internal\/[\w/]*))/;
@@ -106,13 +109,10 @@ function setup(ctx, name = '') {
 		let copy = { ...ctx };
 		let run = runner.bind(0, copy, name);
 		Object.assign(ctx, context(copy.state));
-		QUEUE[globalThis.UVU_INDEX || 0].push(run);
+		UVU_QUEUE[globalThis.UVU_INDEX || 0].push(run);
 	};
 	return test;
 }
-
-export const QUEUE = [];
-isCLI || QUEUE.push([null]);
 
 export const suite = (name = '', state = {}) => setup(context(state), name);
 export const test = suite();
@@ -121,7 +121,7 @@ export async function exec(bail) {
 	let timer = hrtime();
 	let done=0, total=0, skips=0, code=0;
 
-	for (let group of QUEUE) {
+	for (let group of UVU_QUEUE) {
 		if (total) write('\n');
 
 		let name = group.shift();

--- a/test/uvu.js
+++ b/test/uvu.js
@@ -2,16 +2,6 @@ import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import * as uvu from '../src/index';
 
-const QUEUE = suite('QUEUE');
-
-QUEUE('should be an Array', () => {
-	assert.instance(uvu.QUEUE, Array);
-});
-
-QUEUE.run();
-
-// ---
-
 const ste = suite('suite');
 
 ste('should be a function', () => {


### PR DESCRIPTION
Moves `QUEUE` to the `globalThis` scope.

This guarantees that "both halves" of `uvu` are using the same internal value, as described in #69

With the linked reproduction, applying this PR required no other changes in order for the reproduction to work. Additionally, these combinations all worked out of the box:

* `uvu -r esm tests` on Node 14 (default)
* ^^^ + `"type": "module"` on Node 14
* `uvu tests` on Node 14 + `"type": "module"`
* `node -r esm tests/test.js` on Node 14
* ^^^ + `"type": "module"` on Node 14
* `node tests/test.js` on Node 14 + `"type": "module"`

The approach still works within browsers.

---

Closes #69