### PR TITLE
fix(parse): Add `cwd` default; return `requires` boolean

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -20,12 +20,12 @@ sade('uvu [dir] [pattern]')
 	.action(async (dir, pattern, opts) => {
 		try {
 			if (opts.color) process.env.FORCE_COLOR = '1';
-			let { suites } = await parse(dir, pattern, opts);
+			let ctx = await parse(dir, pattern, opts);
 
-			if (hasImport) {
-				await dimport('uvu/run').then(m => m.run(suites, opts));
+			if (!ctx.requires && hasImport) {
+				await dimport('uvu/run').then(m => m.run(ctx.suites, opts));
 			} else {
-				await require('uvu/run').run(suites, opts);
+				await require('uvu/run').run(ctx.suites, opts);
 			}
 		} catch (err) {
 			console.error(err.stack || err.message);

--- a/src/parse.d.ts
+++ b/src/parse.d.ts
@@ -16,6 +16,7 @@ export interface Options {
 export interface Argv {
 	dir: string;
 	suites: Suite[];
+	requires: boolean;
 }
 
 export function parse(dir?: string, pattern?: string|RegExp, opts?: Partial<Options>): Promise<Argv>;

--- a/src/parse.d.ts
+++ b/src/parse.d.ts
@@ -18,5 +18,4 @@ export interface Argv {
 	suites: Suite[];
 }
 
-// TODO: named `parse` export
-export function parse(dir: string, pattern: string, opts?: Partial<Options>): Promise<Argv>;
+export function parse(dir?: string, pattern?: string|RegExp, opts?: Partial<Options>): Promise<Argv>;

--- a/src/parse.js
+++ b/src/parse.js
@@ -12,7 +12,7 @@ export async function parse(dir, pattern, opts = {}) {
 	if (pattern) pattern = toRegex(pattern);
 	else if (dir) pattern = /(((?:[^\/]*(?:\/|$))*)[\\\/])?\w+\.([mc]js|[jt]sx?)$/;
 	else pattern = /((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|[jt]sx?)$/i;
-	dir = resolve(opts.cwd, dir || '.');
+	dir = resolve(opts.cwd || '.', dir || '.');
 
 	[].concat(opts.require || []).filter(Boolean).forEach(name => {
 		let tmp = exists(name);

--- a/src/parse.js
+++ b/src/parse.js
@@ -14,15 +14,16 @@ export async function parse(dir, pattern, opts = {}) {
 	else pattern = /((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|[jt]sx?)$/i;
 	dir = resolve(opts.cwd || '.', dir || '.');
 
-	[].concat(opts.require || []).filter(Boolean).forEach(name => {
+	let suites = [];
+	let requires = [].concat(opts.require || []).filter(Boolean);
+	let ignores = ['node_modules'].concat(opts.ignore || []).map(toRegex);
+
+	requires.forEach(name => {
 		let tmp = exists(name);
 		if (tmp) return require(tmp);
 		if (tmp = exists(resolve(name))) return require(tmp);
 		throw new Error(`Cannot find module '${name}'`);
 	});
-
-	let suites = [];
-	let ignores = ['node_modules'].concat(opts.ignore || []).map(toRegex);
 
 	await totalist(dir, (rel, abs) => {
 		if (pattern.test(rel) && !ignores.some(x => x.test(rel))) {
@@ -32,5 +33,5 @@ export async function parse(dir, pattern, opts = {}) {
 
 	suites.sort((a, b) => a.name.localeCompare(b.name));
 
-	return { dir, suites };
+	return { dir, suites, requires: requires.length > 0 };
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,0 +1,137 @@
+import { suite } from 'uvu';
+import { readdirSync } from 'fs';
+import { isAbsolute } from 'path';
+import * as assert from 'uvu/assert';
+import * as $ from '../src/parse';
+
+const FILES = readdirSync(__dirname);
+
+const parse = suite('parse');
+
+parse('should be a function', () => {
+	assert.type($.parse, 'function');
+});
+
+parse('should rely on defaults', async () => {
+	// dirname to avoid node_modules
+	let output = await $.parse(__dirname);
+
+	assert.type(output, 'object');
+	assert.is(output.dir, __dirname);
+
+	assert.instance(output.suites, Array);
+	assert.is(output.suites.length, FILES.length);
+
+	output.suites.forEach(suite => {
+		assert.is.not(isAbsolute(suite.name));
+		assert.is(FILES.includes(suite.name), true, '~> suite.name is relative filename')
+		assert.is(isAbsolute(suite.file), true, '~> suite.file is absolute path');
+	});
+});
+
+parse.run();
+
+// ---
+
+const dir = suite('dir');
+
+dir('should accept relative `dir` input', async () => {
+	let output = await $.parse('test');
+
+	assert.type(output, 'object');
+	assert.is(output.dir, __dirname);
+
+	assert.instance(output.suites, Array);
+	assert.is(output.suites.length, FILES.length);
+
+	output.suites.forEach(suite => {
+		assert.is.not(isAbsolute(suite.name));
+		assert.is(FILES.includes(suite.name), true, '~> suite.name is relative filename')
+		assert.is(isAbsolute(suite.file), true, '~> suite.file is absolute path');
+	});
+});
+
+dir.run();
+
+// ---
+
+const pattern = suite('pattern');
+
+pattern('should only load tests matching pattern :: RegExp', async () => {
+	let foo = await $.parse(__dirname, /assert/);
+	assert.is(foo.suites[0].name, 'assert.js');
+	assert.is(foo.suites.length, 1);
+
+	let bar = await $.parse(__dirname, /^uvu\.js$/);
+	assert.is(bar.suites[0].name, 'uvu.js');
+	assert.is(bar.suites.length, 1);
+});
+
+pattern('should only load tests matching pattern :: string', async () => {
+	let foo = await $.parse(__dirname, 'assert');
+	assert.is(foo.suites[0].name, 'assert.js');
+	assert.is(foo.suites.length, 1);
+
+	let bar = await $.parse(__dirname, '^uvu\\.js$');
+	assert.is(bar.suites[0].name, 'uvu.js');
+	assert.is(bar.suites.length, 1);
+});
+
+pattern.run();
+
+// ---
+
+const cwd = suite('options.cwd');
+
+cwd('should affect from where `dir` resolves', async () => {
+	let foo = await $.parse('.', '', { cwd: __dirname });
+	assert.is(foo.suites.length, FILES.length);
+	foo.suites.forEach(suite => {
+		assert.is(FILES.includes(suite.name), true, '~> suite.name is relative filename')
+		assert.is(isAbsolute(suite.file), true, '~> suite.file is absolute path');
+	});
+});
+
+cwd.run();
+
+// ---
+
+const ignore = suite('options.ignore');
+
+ignore('should ignore test files matching :: RegExp', async () => {
+	let foo = await $.parse(__dirname, '', { ignore: /assert/ });
+	assert.is(foo.suites.find(x => x.name === 'assert.js'), undefined);
+	assert.is(foo.suites.length, FILES.length - 1);
+
+	let bar = await $.parse(__dirname, '', { ignore: /^uvu\.js$/ });
+	assert.is(bar.suites.find(x => x.name === 'uvu.js'), undefined);
+	assert.is(bar.suites.length, FILES.length - 1);
+});
+
+ignore('should ignore test files matching :: RegExp', async () => {
+	let foo = await $.parse(__dirname, '', { ignore: 'assert' });
+	assert.is(foo.suites.find(x => x.name === 'assert.js'), undefined);
+	assert.is(foo.suites.length, FILES.length - 1);
+
+	let bar = await $.parse(__dirname, '', { ignore: 'uvu.js' });
+	assert.is(bar.suites.find(x => x.name === 'uvu.js'), undefined);
+	assert.is(bar.suites.length, FILES.length - 1);
+});
+
+ignore.run();
+
+// ---
+
+const requires = suite('options.require');
+
+requires('should throw on invalid value(s)', async () => {
+	try {
+		await $.parse(__dirname, '', { require: ['foobar'] });
+		assert.unreachable('should have thrown');
+	} catch (err) {
+		assert.instance(err, Error);
+		assert.match(err.message, `Cannot find module 'foobar'`);
+	}
+});
+
+requires.run();

--- a/test/parse.js
+++ b/test/parse.js
@@ -18,6 +18,7 @@ parse('should rely on defaults', async () => {
 
 	assert.type(output, 'object');
 	assert.is(output.dir, __dirname);
+	assert.is(output.requires, false);
 
 	assert.instance(output.suites, Array);
 	assert.is(output.suites.length, FILES.length);
@@ -40,6 +41,7 @@ dir('should accept relative `dir` input', async () => {
 
 	assert.type(output, 'object');
 	assert.is(output.dir, __dirname);
+	assert.is(output.requires, false);
 
 	assert.instance(output.suites, Array);
 	assert.is(output.suites.length, FILES.length);
@@ -132,6 +134,11 @@ requires('should throw on invalid value(s)', async () => {
 		assert.instance(err, Error);
 		assert.match(err.message, `Cannot find module 'foobar'`);
 	}
+});
+
+requires('should `require` valid value(s)', async () => {
+	let foo = await $.parse(__dirname, '', { require: ['esm'] });
+	assert.is(foo.requires, true);
 });
 
 requires.run();


### PR DESCRIPTION
* Fixes the types
* Adds `uvu/parse` tests
* Adds default to `opts.cwd`
* Returns new `requires` boolean indicating whether or not `-r/--require` was defined
    _Better here than doing it differently inside `bin.js` directly._

---

Related to #72 – but **does not** replace #73
We'll see what other conditions can still trigger `ERR_UNKNOWN_FILE_EXTENSION` error and go from there with concrete example(s). I _suspect_ it's still possible to be thrown, but not sure exactly how. @tolu Let's keep both of your items open so that if/when any issues still arise, we already have a billboard and a springboard for them.