### PR TITLE
change assert.ok to narrow the type

### DIFF
--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -1,7 +1,7 @@
 type Types = 'string' | 'number' | 'boolean' | 'object' | 'undefined' | 'function';
 
 export type Message = string | Error;
-export function ok(actual: any, msg?: Message): void;
+export function ok(actual: any, msg?: Message): asserts actual;
 export function is(actual: any, expects: any, msg?: Message): void;
 export function equal(actual: any, expects: any, msg?: Message): void;
 export function type(actual: any, expects: Types, msg?: Message): void;


### PR DESCRIPTION
This changes the return type of `assert.ok` from `void` to `asserts actual`, making type narrowing work:

```ts
type A = {ok: true, data: any} | {ok: false};
const a = {ok: true, data: 1} as A;
assert.ok(a.ok);
a.data; // type error! without this change, type does not narrow
```

This is the same as [`assert.ok` in `@types/node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/46b370ffd2c8e81b21fac6a50f85be7a32d70efc/types/node/assert.d.ts#L62):

```ts
function ok(value: any, message?: string | Error): asserts value;
```

This is more complicated for `assert.not.ok`. The syntax `asserts !val` does not work, you have to say `asserts val is $type`. So, does a falsy union type like `asserts actual is false | '' | null | undefined | 0 | -0 | typeof NaN` work correctly for all cases? It does for my code, but I don't know if it's correct - I think it is? As a workaround, you can negate the condition and use `ok` to get that behavior with this PR. I'll follow up on this and some other types in an issue soon. (sorry this may be straightforward, but I believe I couldn't get this to work in a previous TS version, but it works now for the cases I have)

AFAIK this change is only a win - because it only narrows the type, I don't think it can cause errors. The other changes I want to make may break existing typechecks.