### PR TITLE
docs: added information for assert.match and assert.not.match

### DIFF
--- a/docs/api.assert.md
+++ b/docs/api.assert.md
@@ -83,6 +83,15 @@ assert.instance([1, 2, 3], Array);
 assert.instance(/foobar/gi, RegExp);
 ```
 
+### match(actual: string, expects: RegExp | String, msg?: Message)
+Assert that `actual` matches the `expects` regular expression.
+
+```js
+assert.match('hello world', 'wor');
+assert.match('hello world', /hello/g);
+assert.match('hello world', RegExp('hello'));
+```
+
 ### snapshot(actual: string, expects: string, msg?: Message)
 Assert that `actual` matches the `expects` multi-line string.
 

--- a/docs/api.assert.md
+++ b/docs/api.assert.md
@@ -185,6 +185,15 @@ assert.not.instance([1, 2, 3], String);
 assert.not.instance(/foobar/gi, Date);
 ```
 
+### not.match(actual: string, expects: RegExp | String, msg?: Message)
+Assert that `actual` does not match the `expects` regular expression.
+
+```js
+assert.not.match('hello world', 'other');
+assert.not.match('hello world', /other/g);
+assert.not.match('hello world', RegExp('other'));
+```
+
 ### not.snapshot(actual: string, expects: string, msg?: Message)
 Assert that `actual` does not match the `expects` snapshot.
 

--- a/docs/api.assert.md
+++ b/docs/api.assert.md
@@ -84,12 +84,14 @@ assert.instance(/foobar/gi, RegExp);
 ```
 
 ### match(actual: string, expects: RegExp | String, msg?: Message)
-Assert that `actual` matches the `expects` regular expression.
+Assert that `actual` matches the `expects` pattern.
+
+When `expects` is a regular expression, it must match the `actual` value.
+When `expects` is a string, it must exist within the `actual` value as a substring.
 
 ```js
 assert.match('hello world', 'wor');
-assert.match('hello world', /hello/g);
-assert.match('hello world', RegExp('hello'));
+assert.match('hello world', /^hel/);
 ```
 
 ### snapshot(actual: string, expects: string, msg?: Message)
@@ -186,12 +188,14 @@ assert.not.instance(/foobar/gi, Date);
 ```
 
 ### not.match(actual: string, expects: RegExp | String, msg?: Message)
-Assert that `actual` does not match the `expects` regular expression.
+Assert that `actual` does not match the `expects` pattern.
+
+When `expects` is a regular expression, it must not match the `actual` value.
+When `expects` is a string, it must not exist within the `actual` value as a substring.
 
 ```js
 assert.not.match('hello world', 'other');
 assert.not.match('hello world', /other/g);
-assert.not.match('hello world', RegExp('other'));
 ```
 
 ### not.snapshot(actual: string, expects: string, msg?: Message)


### PR DESCRIPTION
Hello!

On [assert documentation](https://github.com/lukeed/uvu/blob/master/docs/api.assert.md), there is no mention of `assert.match` and `assert.not.match`. So, I've added those along with some simple examples.

Thanks!