### PR TITLE
feat: nested groups

### DIFF
--- a/docs/api.uvu.md
+++ b/docs/api.uvu.md
@@ -380,4 +380,4 @@ Nested suites don't share their parent's context, instead you can pass in a diff
 
 `run()`, `skip()` and `only()` operations affect groups in a recursive way. This means that running a suite/group makes all the groups contained within it run as well, and skipping a suite/group skips all the groups contained within it as well.
 
-To understand the feature better you can checkout [`/examples`](/examples).
+To understand the feature better you can checkout [`/examples/groups`](/examples/groups).

--- a/docs/api.uvu.md
+++ b/docs/api.uvu.md
@@ -88,6 +88,15 @@ Start/Add the suite to the `uvu` test queue.
 
 > **Important:** You **must** call this method in order for your suite to be run!
 
+### suite.group(name, context, callback)
+Create a new suite belonging to the current suite. <br>Please see [Groups](#groups) for more information.
+
+### suite.group.only(name, context, callback)
+Inside this suite, only run this group. <br>This is a shortcut for isolating one (or more) groups. <br>Please see [Groups](#groups) for more information.
+
+### suite.group.skip(name, context, callback)
+Skip this group entirely. <br>Please see [Groups](#groups) for more information.
+
 ***Example***
 
 > Check out [`/examples`](/examples) for a list of working demos!
@@ -363,3 +372,12 @@ User('should not have Teams initially', async context => {
 
 User.run();
 ```
+
+## Groups
+Groups are just named suites nested under other named suites. This gives you the ability to group tests belonging to a specific suite.
+
+Nested suites don't share their parent's context, instead you can pass in a different (or the same if you would like) context when creating a group.
+
+`run()`, `skip()` and `only()` operations affect groups in a recursive way. This means that running a suite/group makes all the groups contained within it run as well, and skipping a suite/group skips all the groups contained within it as well.
+
+To understand the feature better you can checkout [`/examples`](/examples).

--- a/examples/groups/package.json
+++ b/examples/groups/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "uvu tests"
+  },
+  "devDependencies": {
+    "uvu": "^0.0.18"
+  }
+}

--- a/examples/groups/src/client.js
+++ b/examples/groups/src/client.js
@@ -1,0 +1,22 @@
+class Client {
+	authenticate(username, password) {
+		if (username == 'admin' && password == 'verystrong') return true;
+		if (username == 'user' && password == 'strong') return true;
+		if (username == 'guest') return true;
+		return false;
+	}
+	isPasswordStrong(password) {
+		if (password.length < 16) return false;
+		let upper = 0, number = 0, special = 0;
+		const regexp = /^[A-Za-z0-9]+$/;
+		for (const char of password) {
+			if (!regexp.test(char)) special++;
+			else if (char >= '0' && char <= '9') number++;
+			else if (char.toUpperCase() == char) upper++;
+		}
+		if (upper < 4 || number < 2 || special < 2) return false;
+		return true;
+	}
+}
+
+module.exports = Client;

--- a/examples/groups/src/utils.js
+++ b/examples/groups/src/utils.js
@@ -1,0 +1,15 @@
+class Utils {
+	add (a, b) {
+		return a + b;
+	}
+	getLength(input) {
+		if (input.length) return input.length;
+		return 0;
+	}
+	getAsString(input) {
+		if (typeof input == 'object') return JSON.stringify(input);
+		return input.toString();
+	}
+}
+
+module.exports = Utils;

--- a/examples/groups/tests/app.js
+++ b/examples/groups/tests/app.js
@@ -1,0 +1,75 @@
+const { suite } = require('uvu');
+const assert = require('uvu/assert');
+const Client = require('../src/client');
+const Utils = require('../src/utils');
+
+const app = suite('app');
+const class1 = new Client();
+const class2 = new Utils();
+
+app.group('client', {}, client => {
+	client.group('authenticate()', {}, auth => {
+		auth('accept admin pass, reject other passwords', () => {
+			assert.ok(class1.authenticate('admin', 'verystrong'));
+			assert.not(class1.authenticate('admin', 'weak'));
+		});
+		auth('accept normal pass, reject other passwords', () => {
+			assert.ok(class1.authenticate('user', 'strong'));
+			assert.not(class1.authenticate('user', 'weak'));
+		});
+		auth('no password for guest', () => {
+			assert.ok(class1.authenticate('guest', 'strong'));
+			assert.ok(class1.authenticate('guest', ''));
+		});
+	});
+	client.group('isPasswordStrong()', {}, pass => {
+		pass('reject short password', () => {
+			assert.not(class1.isPasswordStrong('short'));
+		});
+		pass('reject short password with sufficient non-lowercase alphabetic values', () => {
+			assert.not(class1.isPasswordStrong('1234+-AA'));
+		});
+		pass('reject long password with insufficient non-lowercase alphabetic values', () => {
+			assert.not(class1.isPasswordStrong('verystrongpassword'));
+		});
+		pass('accept long password meeting requirements', () => {
+			assert.ok(class1.isPasswordStrong('P@SSw0rD!6978//K'));
+		});
+	});
+});
+
+app.group('utils', {}, utils => {
+	utils.group('add()', {}, add => {
+		add('two integers', () => {
+			assert.equal(class2.add(1, 2), 3);
+		});
+		add('two integers, one negative', () => {
+			assert.equal(class2.add(1, -2), -1);
+		});
+		add('two floats', () => {
+			assert.equal(class2.add(1.25, 1.25), 2.5);
+		});
+	});
+	utils.group('getLength()', {}, length => {
+		length('returns string length', () => {
+			assert.equal(class2.getLength('12345678'), 8);
+		});
+		length('returns array length', () => {
+			assert.equal(class2.getLength([1, 2, 3, 4]), 4);
+		});
+		length('returns 0 if input does not have length function', () => {
+			assert.equal(class2.getLength({ok: true}), 0);
+		});
+	});
+	utils.group('getAsString()', {}, str => {
+		str('return integer as string', () => {
+			assert.equal(class2.getAsString(376), '376');
+		});
+		str('return object as JSON.stringified', () => {
+			const obj = {ok: true, count: 3, msg: 'asd'};
+			assert.equal(class2.getAsString(obj), JSON.stringify(obj));
+		});
+	});
+});
+
+app.run();

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,9 @@ function setup(ctx, name = '') {
 		}
 	};
 	test.group = (name, state, handler) => {
-		const ns = setup(context({...state, __depth__: ctx.state.__depth__ + 1, __skipped__: ctx.state.__skipped__}), name);
+		state.__depth__ = ctx.state.__depth__ + 1;
+		state.__skipped__ = ctx.state.__skipped__;
+		const ns = setup(context(state), name);
 		handler(ns);
 		ctx.groups.push(ns);
 	};
@@ -141,7 +143,9 @@ function setup(ctx, name = '') {
 		ctx.groups.push(ns);
 	};
 	test.group.only = (name, state, handler) => {
-		const ns = setup(context({...state, __depth__: ctx.state.__depth__ + 1, __skipped__: ctx.state.__skipped__}), name);
+		state.__depth__ = ctx.state.__depth__ + 1;
+		state.__skipped__ = ctx.state.__skipped__;
+		const ns = setup(context(state), name);
 		handler(ns);
 		ctx.groupsOnly.push(ns);
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ let hrtime = (now = Date.now()) => () => (Date.now() - now).toFixed(2) + 'ms';
 let write = console.log;
 
 const into = (ctx, key) => (name, handler) => ctx[key].push({ name, handler });
-const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[], only:[], skips:0, state });
+const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[], only:[], skips:0, groups:[], state });
 const milli = arr => (arr[0]*1e3 + arr[1]/1e6).toFixed(2) + 'ms';
 const hook = (ctx, key) => handler => ctx[key].push(handler);
 
@@ -38,36 +38,39 @@ const FAILURE = kleur.bold().bgRed(' FAIL ');
 const FILE = kleur.bold().underline().white;
 const SUITE = kleur.bgWhite().bold;
 
-function stack(stack, idx) {
+function stack(stack, idx, padding) {
 	let i=0, line, out='';
 	let arr = stack.substring(idx).replace(/\\/g, '/').split('\n');
 	for (; i < arr.length; i++) {
 		line = arr[i].trim();
 		if (line.length && !IGNORE.test(line)) {
-			out += '\n    ' + line;
+			out += '\n    ' + padding + line;
 		}
 	}
 	return kleur.grey(out) + '\n';
 }
 
-function format(name, err, suite = '') {
+function format(name, err, padding, suite = '') {
 	let { details, operator='' } = err;
 	let idx = err.stack && err.stack.indexOf('\n');
 	if (err.name.startsWith('AssertionError') && !operator.includes('not')) details = compare(err.actual, err.expected); // TODO?
-	let str = '  ' + FAILURE + (suite ? kleur.red(SUITE(` ${suite} `)) : '') + ' ' + QUOTE + kleur.red().bold(name) + QUOTE;
-	str += '\n    ' + err.message + (operator ? kleur.italic().dim(`  (${operator})`) : '') + '\n';
-	if (details) str += GUTTER + details.split('\n').join(GUTTER);
-	if (!!~idx) str += stack(err.stack, idx);
+	let str = padding + '  ' + FAILURE + (suite ? kleur.red(SUITE(` ${suite} `)) : '') + ' ' + QUOTE + kleur.red().bold(name) + QUOTE;
+	str += '\n    ' + padding + err.message + (operator ? kleur.italic().dim(`  (${operator})`) : '') + '\n';
+	if (details) str += GUTTER + padding + details.split('\n').join(GUTTER + padding);
+	if (!!~idx) str += stack(err.stack, idx, padding);
 	return str + '\n';
 }
 
 async function runner(ctx, name) {
-	let { only, tests, before, after, bEach, aEach, state } = ctx;
+	let { only, tests, before, after, bEach, aEach, state, groups} = ctx;
 	let hook, test, arr = only.length ? only : tests;
 	let num=0, errors='', total=arr.length;
+	let padding = '';
+	const pad = '  ';
+	for (let i = 0; i < state.__depth__; ++i) padding += pad;
 
 	try {
-		if (name) write(SUITE(kleur.black(` ${name} `)) + ' ');
+		if (name) write(padding + SUITE(kleur.black(` ${name} `)) + ' ');
 		for (hook of before) await hook(state);
 
 		for (test of arr) {
@@ -81,7 +84,7 @@ async function runner(ctx, name) {
 			} catch (err) {
 				for (hook of aEach) await hook(state);
 				if (errors.length) errors += '\n';
-				errors += format(test.name, err, name);
+				errors += format(test.name, err, padding, name);
 				write(FAIL);
 			}
 		}
@@ -98,6 +101,7 @@ async function runner(ctx, name) {
 function setup(ctx, name = '') {
 	ctx.state.__test__ = '';
 	ctx.state.__suite__ = name;
+	if (!ctx.state.__depth__) ctx.state.__depth__ = 0;
 	const test = into(ctx, 'tests');
 	test.before = hook(ctx, 'before');
 	test.before.each = hook(ctx, 'bEach');
@@ -110,6 +114,14 @@ function setup(ctx, name = '') {
 		let run = runner.bind(0, copy, name);
 		Object.assign(ctx, context(copy.state));
 		UVU_QUEUE[globalThis.UVU_INDEX || 0].push(run);
+		for (const group of copy.groups) {
+			const ns = setup(context({...group.context, __depth__: ctx.state.__depth__ + 1}), group.name);
+			group.handler(ns);
+			ns.run();
+		}
+	};
+	test.group = (name, context, handler) => {
+		ctx.groups.push({name, context, handler});
 	};
 	return test;
 }

--- a/test/groups.js
+++ b/test/groups.js
@@ -1,0 +1,283 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+
+const groups = suite('suite.group()');
+
+groups.group('sub1', {}, sub1 => {
+	sub1('test1', () => {
+		assert.ok('i should run');
+	});
+	sub1.group('doubleSub1', {}, doubleSub1 => {
+		doubleSub1('test2', () => {
+			assert.ok('i should run too');
+		});
+	});
+});
+
+groups.group('sub2', {}, sub2 => {
+	sub2('test3', () => {
+		assert.ok('i should run too');
+	});
+});
+
+// ---
+
+const skips = suite('suite.group.skip()');
+
+const skips_state = {
+	each: 0,
+};
+
+skips.group('sub1', {}, sub1 => {
+	sub1.skip('skip1', () => {
+		assert.unreachable('i should not run');
+	});
+	sub1.group.skip('doubleSub1', {}, doubleSub1 => {
+		doubleSub1('skip2', () => {
+			assert.unreachable('parent group is skipped, i should not run');
+		});
+		doubleSub1.group('tripleSub1', {}, tripleSub1 => {
+			tripleSub1('skip3', () => {
+				assert.unreachable('i should not run even though parent is not explicitly skipped');
+			});
+		});
+	});
+	sub1('reach1', () => {
+		assert.ok('i should run');
+	});
+});
+
+skips.run();
+
+// ---
+
+const only = suite('suite.group.only()');
+
+only.group('sub1', {}, sub1 => {
+	sub1('test1', () => {
+		assert.unreachable('i should not run');
+	});
+	sub1.group('doubleSub1', {}, doubleSub1 => {
+		doubleSub1('test2', () => {
+			assert.unreachable('i should not run');
+		});
+	});
+});
+
+only.group.skip('sub2', {}, sub2 => {
+	sub2('test3', () => {
+		assert.unreachable('i should not run');
+	});
+});
+
+only.group.only('sub3', {}, sub3 => {
+	sub3('test4', () => {
+		assert.ok('i should run');
+	});
+	sub3.group('doubleSub2', {}, doubleSub2 => {
+		doubleSub2('test5', () => {
+			assert.ok('i should run');
+		});
+	});
+});
+
+only.group.only('sub4', {}, sub4 => {
+	sub4('test6', () => {
+		assert.ok('i should run');
+	});
+});
+
+only.run();
+
+// ---
+
+const context1Root = suite('context #1');
+
+context1Root.group('context1', {}, context1 => {
+	context1.before(ctx => {
+		assert.is(ctx.before, undefined);
+		assert.is(ctx.after, undefined);
+		assert.is(ctx.each, undefined);
+
+		Object.assign(ctx, {
+			before: 1,
+			after: 0,
+			each: 0,
+		});
+	});
+
+	context1.after(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 0);
+		ctx.after++;
+	});
+
+	context1.before.each(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 0);
+		ctx.each++;
+	});
+
+	context1.after.each(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+		ctx.each--;
+	});
+
+	context1('test #1', ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+	});
+
+	context1('test #2', ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+	});
+});
+
+context1Root.run();
+
+// ---
+
+const context2Root = suite('context #2');
+
+context2Root.group('context2', {
+	before: 0,
+	after: 0,
+	each: 0,
+}, context2 => {
+	context2.before(ctx => {
+		assert.is(ctx.before, 0);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 0);
+		ctx.before++;
+	});
+
+	context2.after(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 0);
+		ctx.after++;
+	});
+
+	context2.before.each(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 0);
+		ctx.each++;
+	});
+
+	context2.after.each(ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+		ctx.each--;
+	});
+
+	context2('test #1', ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+	});
+
+	context2('test #2', ctx => {
+		assert.is(ctx.before, 1);
+		assert.is(ctx.after, 0);
+		assert.is(ctx.each, 1);
+	});
+});
+
+context2Root.run();
+
+// ---
+
+const input = {
+	a: 1,
+	b: [2, 3, 4],
+	c: { foo: 5 },
+	set: new Set([1, 2]),
+	date: new Date(),
+	map: new Map,
+};
+
+const context3Root = suite('context #3');
+
+context3Root.group('context3', input, context3 => {
+	context3('should access keys', ctx => {
+		assert.is(ctx.a, input.a);
+		assert.equal(ctx.b, input.b);
+		assert.equal(ctx.c, input.c);
+	});
+
+	context3('should allow context modifications', ctx => {
+		ctx.a++;
+		assert.is(ctx.a, 2, 'ctx modified');
+		assert.is(input.a, 2, 'input modified');
+
+		ctx.b.push(999);
+		assert.equal(ctx.b, [2, 3, 4, 999]);
+		assert.equal(input.b, [2, 3, 4, 999]);
+
+		ctx.c.foo++;
+		assert.is(ctx.c.foo, 6);
+		assert.is(input.c.foo, 6);
+
+		ctx.c.bar = 6;
+		assert.equal(ctx.c, { foo: 6, bar: 6 });
+		assert.equal(input.c, { foo: 6, bar: 6 });
+	});
+
+	context3('should allow self-referencing instance(s) within context', ctx => {
+		const { date, set, map } = ctx;
+
+		assert.type(date.getTime(), 'number');
+		assert.equal([...set.values()], [1, 2]);
+		assert.equal([...map.entries()], []);
+	});
+});
+
+context3Root.run();
+
+// ---
+
+const breadcrumbsRoot = suite('breadcrumbs');
+
+breadcrumbsRoot.group('breadcrumbs', {count: 1}, breadcrumbs => {
+	breadcrumbs.before(ctx => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, '');
+	});
+
+	breadcrumbs.after(ctx => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, '');
+	});
+
+	breadcrumbs.before.each(ctx => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, `test #${ctx.count}`);
+	});
+
+	breadcrumbs.after.each(ctx => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, `test #${ctx.count++}`);
+	});
+
+	breadcrumbs('test #1', (ctx) => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, 'test #1');
+	});
+
+	breadcrumbs('test #2', (ctx) => {
+		assert.is(ctx.__suite__, 'breadcrumbs');
+		assert.is(ctx.__test__, 'test #2');
+	});
+});
+
+
+breadcrumbsRoot.run();


### PR DESCRIPTION
This PR aims to implement the feature described in #43.

Because there wasn't a definitive agreement on how this should be implemented I just chose one of the suggestions and implemented it. However I'd be glad to change anything if requested.

I'd appreciate any feedback, especially on the `suite.group.only()` and `suite.group.skip()` functions. They feel a bit *hacky* but I didn't have a better idea.

I also added tests and an example to demonstrate how the feature currently works. Updated documentation too, although not sure whether `index.d.ts` is .gitignore'd intentionally, or just a problem with my setup.

Let me know what you think.
