### PR TITLE
Add assert.rejects and assert.not.rejects methods for promises

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -97,6 +97,26 @@ export function throws(blk, exp, msg) {
 	}
 }
 
+export async function rejects(blk, exp, msg) {
+	if (!msg && typeof exp === 'string') {
+		msg = exp; exp = null;
+	}
+
+	try {
+		await blk();
+		assert(false, false, true, 'rejects', false, 'Expected promise to reject', msg);
+	} catch (err) {
+		if (err instanceof Assertion) throw err;
+
+		if (typeof exp === 'function') {
+			assert(exp(err), false, true, 'rejects', false, 'Expected promise to reject matching exception', msg);
+		} else if (exp instanceof RegExp) {
+			const errorMessage = err instanceof Error ? err.message : err
+			assert(exp.test(errorMessage), false, true, 'rejects', false, `Expected promise to reject matching exception \`${String(exp)}\` pattern`, msg);
+		}
+	}
+}
+
 // ---
 
 export function not(val, msg) {
@@ -155,6 +175,24 @@ not.throws = function (blk, exp, msg) {
 			assert(!exp.test(err.message), true, false, 'not.throws', false, `Expected function not to throw exception matching \`${String(exp)}\` pattern`, msg);
 		} else if (!exp) {
 			assert(false, true, false, 'not.throws', false, 'Expected function not to throw', msg);
+		}
+	}
+}
+
+not.rejects = async function (blk, exp, msg) {
+	if (!msg && typeof exp === 'string') {
+		msg = exp; exp = null;
+	}
+
+	try {
+		await blk();
+	} catch (err) {
+		if (typeof exp === 'function') {
+			assert(!exp(err), true, false, 'not.rejects', false, 'Expected function not to reject promise matching exception', msg);
+		} else if (exp instanceof RegExp) {
+			assert(!exp.test(err instanceof Error ? err.message : err), true, false, 'not.rejects', false, `Expected function not to reject promise exception matching \`${String(exp)}\` pattern`, msg);
+		} else if (!exp) {
+			assert(false, true, false, 'not.rejects', false, 'Expected function not to reject promise', msg);
 		}
 	}
 }


### PR DESCRIPTION
This implements the async equivalent of `assert.throws()` for promise rejections (and releated tests, based on the tests for `throws`).

While this can be handled [via a workaround](https://github.com/lukeed/uvu/issues/35), having a separate method does cut down on boilerplate.

Instead of overloading `throws`, I feel it makes sense to have a separate method for promise rejections. This way `throws` is always sync and `rejects` is always async.

I understand if you’d rather just keep `throws` and the workaround, just wanted to share my addition upstream. Please feel free to close this pull request and its corresponding issue if you feel this is out of scope or complicates the API beyond what you’re comfortable with.