### PR TITLE
chore: add "vue" example

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "loadr -c tests/setup/loadr.js -- uvu tests -i setup"
+  },
+  "dependencies": {
+    "vue": "^3.2.6"
+  },
+  "devDependencies": {
+    "@vue/compiler-sfc": "^3.2.6",
+    "jsdom": "^17.0.0",
+    "loadr": "^0.1.1",
+    "uvu": "^0.5.1"
+  }
+}

--- a/examples/vue/src/Count.vue
+++ b/examples/vue/src/Count.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  count: { type: Number, default: 5 }
+})
+
+const value = ref(props.count)
+</script>
+
+<template>
+  <button id="decr" @click="value--">--</button>
+  <span>{{ value }}</span>
+  <button id="incr" @click="value++">++</button>
+</template>

--- a/examples/vue/tests/Count.js
+++ b/examples/vue/tests/Count.js
@@ -1,0 +1,59 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import * as ENV from './setup/env.js'
+
+import Count from '../src/Count.vue'
+
+test.before.each(ENV.reset)
+
+test('should render with "5" by default', () => {
+  const { container } = ENV.render(Count)
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>5</span><button id="incr">++</button>`
+  )
+})
+
+test('should accept custom `count` prop', () => {
+  const { container } = ENV.render(Count, { count: 99 })
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>99</span><button id="incr">++</button>`
+  )
+})
+
+test('should increment count after `button#incr` click', async () => {
+  const { container } = ENV.render(Count)
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>5</span><button id="incr">++</button>`
+  )
+
+  await ENV.fire(container.querySelector('#incr'), 'click')
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>6</span><button id="incr">++</button>`
+  )
+})
+
+test('should decrement count after `button#decr` click', async () => {
+  const { container } = ENV.render(Count)
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>5</span><button id="incr">++</button>`
+  )
+
+  await ENV.fire(container.querySelector('#decr'), 'click')
+
+  assert.snapshot(
+    container.innerHTML,
+    `<button id="decr">--</button><span>4</span><button id="incr">++</button>`
+  )
+})
+
+test.run()

--- a/examples/vue/tests/setup/env.js
+++ b/examples/vue/tests/setup/env.js
@@ -1,0 +1,19 @@
+import './window.js' // Must be imported before vue
+import { createApp, nextTick } from 'vue'
+
+export function reset() {
+  window.document.title = ''
+  window.document.head.outerHTML = ''
+}
+
+export function render(component, props = {}) {
+  const container = window.document.body
+  const app = createApp(component, props).mount(container)
+  return { container, app }
+}
+
+export function fire(elem, event, details) {
+  const evt = new window.Event(event, details)
+  elem.dispatchEvent(evt)
+  return nextTick()
+}

--- a/examples/vue/tests/setup/loadr.js
+++ b/examples/vue/tests/setup/loadr.js
@@ -1,0 +1,1 @@
+export const loaders = ['./tests/setup/vue-loader.js']

--- a/examples/vue/tests/setup/vue-loader.js
+++ b/examples/vue/tests/setup/vue-loader.js
@@ -1,0 +1,75 @@
+import {
+  parse,
+  compileScript,
+  compileTemplate,
+  rewriteDefault
+} from '@vue/compiler-sfc'
+import { basename } from 'path'
+
+const COMP_IDENTIFIER = `__sfc__`
+
+export function getFormat(url, context, defaultGetFormat) {
+  return url.endsWith('.vue')
+    ? { format: 'module' }
+    : defaultGetFormat(url, context, defaultGetFormat)
+}
+
+export function transformSource(source, context, defaultTransformSource) {
+  const { url } = context
+
+  if (!url.endsWith('.vue')) {
+    return defaultTransformSource(source, context, defaultTransformSource)
+  }
+
+  const filename = basename(url)
+
+  const { descriptor, errors } = parse(source.toString(), { filename })
+  if (errors.length > 0) {
+    errors.forEach((error) => console.error(error))
+  }
+
+  let code
+  let bindings
+  if (descriptor.script || descriptor.scriptSetup) {
+    const compiledScript = compileScript(descriptor, {
+      id: descriptor.filename,
+      refTransform: true,
+      inlineTemplate: true
+    })
+    code = rewriteDefault(compiledScript.content, COMP_IDENTIFIER)
+    bindings = compiledScript.bindings
+  } else {
+    code = `const ${COMP_IDENTIFIER} = {}`
+  }
+
+  if (descriptor.template && !descriptor.scriptSetup) {
+    const templateResult = compileTemplate({
+      source: descriptor.template.content,
+      filename: descriptor.filename,
+      id: descriptor.filename,
+      scoped: descriptor.styles.some((s) => s.scoped),
+      slotted: descriptor.slotted,
+      ssr: false,
+      ssrCssVars: descriptor.cssVars,
+      isProd: false,
+      compilerOptions: {
+        bindingMetadata: bindings
+      }
+    })
+    if (templateResult.errors.length > 0) {
+      templateResult.errors.forEach((error) => console.error(error))
+    } else {
+      code += `\n${templateResult.code.replace(
+        /\nexport (function) (render)/,
+        `$1 render`
+      )}`
+      code += `\n${COMP_IDENTIFIER}.render = render`
+    }
+  }
+
+  code += `\nexport default ${COMP_IDENTIFIER}`
+
+  return {
+    source: code
+  }
+}

--- a/examples/vue/tests/setup/window.js
+++ b/examples/vue/tests/setup/window.js
@@ -1,0 +1,9 @@
+import { JSDOM } from 'jsdom'
+
+const { window } = new JSDOM('')
+
+global.window = window
+global.document = window.document
+global.navigator = window.navigator
+global.Element = window.Element
+global.SVGElement = window.SVGElement


### PR DESCRIPTION
Hi, 

I wanted to test the possibility of testing Vue components with uvu. 

I converted the Count component from the Svelte example to Vue and I did the same tests.

I'm making this pull request because I think it may interest some people. 

If the example is too specific/complex, close the pull request. Curious people who search in the pull requests will still be able to find the example. 😄

Some remarks:
* It's an ESM project (no CJS).
* Only Vue 3 is supported.
* It's a Node loader that transforms .vue files. This is an experimental feature that may change over time, so it may not work in the future.
* The transformation of the .vue files is a simplified version of [what is done in the Vue SFC playground](https://github.com/vuejs/repl/blob/main/src/transform.ts). Some things are missing like being able to use TypeScript in the SFC script.
* I tested only on Windows. I don't know if it works on other environments. To verify, you have to install the dependencies (`npm i`) and run the tests (`npm test`), they must pass.