### PR TITLE
Set NODE_ENV=test as a default environment

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,6 +3,10 @@ const sade = require('sade');
 const pkg = require('./package');
 const { parse } = require('./parse');
 
+if (process.env.NODE_ENV == null) {
+  process.env.NODE_ENV = 'test';
+}
+
 const dimport = x => new Function(`return import(${ JSON.stringify(x) })`).call(0);
 
 const hasImport = (() => {


### PR DESCRIPTION
This change may be useful in tests which relies on `NODE_ENV='test'` [set in Jest by default](https://github.com/facebook/jest/blob/main/packages/jest-cli/bin/jest.js)