### PR TITLE
Fix exception in diff code with arrays

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -192,7 +192,9 @@ export function stringify(input) {
 }
 
 export function compare(input, expect) {
-	if (Array.isArray(expect)) return arrays(input, expect);
+	if (Array.isArray(expect) && Array.isArray(input)) {
+		return arrays(input, expect);
+	}
 	if (expect instanceof RegExp) return chars(''+input, ''+expect);
 
 	let isA = input && typeof input == 'object';

--- a/src/diff.js
+++ b/src/diff.js
@@ -192,9 +192,7 @@ export function stringify(input) {
 }
 
 export function compare(input, expect) {
-	if (Array.isArray(expect) && Array.isArray(input)) {
-		return arrays(input, expect);
-	}
+	if (Array.isArray(expect) && Array.isArray(input)) return arrays(input, expect);
 	if (expect instanceof RegExp) return chars(''+input, ''+expect);
 
 	let isA = input && typeof input == 'object';

--- a/test/assert.js
+++ b/test/assert.js
@@ -198,6 +198,16 @@ equal('should use deep equality checks', () => {
 	}
 });
 
+// Issue #178
+equal('should throw assertion error on array type mismatch', () => {
+	try {
+		$.equal(null, [1]);
+		assert.unreachable();
+	} catch (err) {
+		assert.instance(err, $.Assertion);
+	}
+})
+
 equal.run();
 
 // ---

--- a/test/assert.js
+++ b/test/assert.js
@@ -198,15 +198,22 @@ equal('should use deep equality checks', () => {
 	}
 });
 
-// Issue #178
 equal('should throw assertion error on array type mismatch', () => {
 	try {
-		$.equal(null, [1]);
+		$.equal(null, []);
 		assert.unreachable();
 	} catch (err) {
 		assert.instance(err, $.Assertion);
 	}
-})
+
+	try {
+		$.equal([], null);
+		assert.unreachable();
+	} catch (err) {
+		assert.instance(err, $.Assertion);
+	}
+
+});
 
 equal.run();
 


### PR DESCRIPTION
This PR addresses an issue where asserting arrays with non-arrays would crash the diff code instead of throwing an assertion error.

Fixes #178