### PR TITLE
Detect BigInt within circular() and properly convert within JSON.stringify

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -181,6 +181,7 @@ export function circular() {
 	return function print(key, val) {
 		if (val === void 0) return '[__VOID__]';
 		if (typeof val === 'number' && val !== val) return '[__NAN__]';
+		if (Object.prototype.toString.call(val) === '[object BigInt]') return val.toString();
 		if (!val || typeof val !== 'object') return val;
 		if (cache.has(val)) return '[Circular]';
 		cache.add(val); return val;

--- a/src/diff.js
+++ b/src/diff.js
@@ -181,7 +181,7 @@ export function circular() {
 	return function print(key, val) {
 		if (val === void 0) return '[__VOID__]';
 		if (typeof val === 'number' && val !== val) return '[__NAN__]';
-		if (Object.prototype.toString.call(val) === '[object BigInt]') return val.toString();
+		if (typeof val === 'bigint') return val.toString();
 		if (!val || typeof val !== 'object') return val;
 		if (cache.has(val)) return '[Circular]';
 		cache.add(val); return val;

--- a/test/diff.js
+++ b/test/diff.js
@@ -1167,4 +1167,11 @@ stringify('should retain `undefined` and `NaN` values :: Array', () => {
 	);
 });
 
+stringify('should handle `BigInt` values correctly', () => {
+	assert.is(
+		$.stringify([BigInt(1), 2n, Object(BigInt(3)), Object(4n)]),
+		'[\n  "1",\n  "2",\n  "3",\n  "4"\n]'
+	);
+})
+
 stringify.run();

--- a/test/diff.js
+++ b/test/diff.js
@@ -2,6 +2,7 @@ import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import * as $ from '../src/diff';
 
+const isNode8 = process.versions.node.startsWith('8.');
 const strip = str => str.replace(/[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-ntqry=><~]))/g, '');
 
 const arrays = suite('arrays');
@@ -1167,12 +1168,17 @@ stringify('should retain `undefined` and `NaN` values :: Array', () => {
 	);
 });
 
-// NOTE: not currently supporting :: Object(BigInt(3)) && Object(4n)
-stringify('should handle `BigInt` values correctly', () => {
-	assert.is(
-		$.stringify([BigInt(1), 2n]),
-		'[\n  "1",\n  "2"\n]'
-	);
-})
+if (!isNode8) {
+	// Not currently supporting :: Object(BigInt(3)) && Object(4n)
+	stringify('should handle `BigInt` values correctly', () => {
+		let bigint = eval('100n'); // avoid Node8 syntax error
+		assert.is($.stringify(BigInt(1)), '"1"');
+		assert.is($.stringify(bigint), '"100"');
+		assert.is(
+			$.stringify([BigInt(1), bigint]),
+			'[\n  "1",\n  "100"\n]'
+		);
+	});
+}
 
 stringify.run();

--- a/test/diff.js
+++ b/test/diff.js
@@ -1167,10 +1167,11 @@ stringify('should retain `undefined` and `NaN` values :: Array', () => {
 	);
 });
 
+// NOTE: not currently supporting :: Object(BigInt(3)) && Object(4n)
 stringify('should handle `BigInt` values correctly', () => {
 	assert.is(
-		$.stringify([BigInt(1), 2n, Object(BigInt(3)), Object(4n)]),
-		'[\n  "1",\n  "2",\n  "3",\n  "4"\n]'
+		$.stringify([BigInt(1), 2n]),
+		'[\n  "1",\n  "2"\n]'
 	);
 })
 


### PR DESCRIPTION
Closes #175.

I used the more complex check of `Object.prototype.toString.call(val) === '[object BigInt]'` instead of just doing `typeof val === 'bigint'` to account for anyone doing something absurd like `Object(2n)` or `Object(BigInt(3)` just to cover all the bases.

Also may kinda smell that this is happening within `circular()`, but I didn't want to do anything more expansive than that. 😅

I [followed the lead of MDN and used `toString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json) as the JSON-friendly output. When you run `console.log` on a `BigInt` it prints it with a trailing `n` to signify it is a special value. I could maybe see doing that instead for clarity? They'd still have to be a string though so the effect isn't entirely the same.

```json5
["1", "2", "3", "4"]
// vs.
["1n", "2n", "3n", "4n"]
```