### PR TITLE
fix(types): fix erroneous return type for `run`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ declare namespace uvu {
 		skip(name?: string, test?: Callback<T>): void;
 		before: Hook<T>;
 		after: Hook<T>
-		run(): () => void;
+		run(): void;
 	}
 }
 


### PR DESCRIPTION
The types for `test.run()` say that it returns a function, but it actually has no return value.