### PR TITLE
fix: make sure that errors from `before` hook are reported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,16 @@ async function runner(ctx, name) {
 
 	try {
 		if (name) write(SUITE(kleur.black(` ${name} `)) + ' ');
-		for (hook of before) await hook(state);
+		for (hook of before) {
+			try {
+				await hook(state);
+			} catch (err) {
+				if (errors.length) errors += '\n';
+				errors += format('before', err, name)
+				write(FAIL)
+				throw err;
+			}
+		}
 
 		for (test of arr) {
 			state.__test__ = test.name;


### PR DESCRIPTION
I've added in a try/catch to catch any errors that happen in the `before` hook so that they can be reported on and properly have the `exit` code of `1`. If you'd like me to update any of the code styles, let me know. Been loving this test runner so far. 

Closes #191 