### PR TITLE
fix(types): allow typescript's new Node16 module resolution to find types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,22 +12,27 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
     "./assert": {
+      "types": "./assert/index.d.ts",
       "require": "./assert/index.js",
       "import": "./assert/index.mjs"
     },
     "./diff": {
+      "types": "./diff/index.d.ts",
       "require": "./diff/index.js",
       "import": "./diff/index.mjs"
     },
     "./parse": {
+      "types": "./parse/index.d.ts",
       "require": "./parse/index.js",
       "import": "./parse/index.mjs"
     },
     "./run": {
+      "types": "./run/index.d.ts",
       "require": "./run/index.js",
       "import": "./run/index.mjs"
     }


### PR DESCRIPTION
TypeScript's new `Node16` module resolution reads exports. It is currently looking for `dist/index.d.ts` or `dist/index.d.mts` as main types for `uvu`, and `<export>/index.d.ts` or `<export>/index.d.mts` for other exports depending on whether `require` or `import` is being used.

Setting the `types` export condition tells typescript where to find the correct types.