### PR TITLE
Connect `actual` and `expects` types in `equal()` and `is()`

### DIFF
--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -1,18 +1,18 @@
 type Types = 'string' | 'number' | 'boolean' | 'object' | 'undefined' | 'function';
 
+export type Message = string | Error;
+
 declare interface Is {
-  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, message?: string): void;
+  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
 	not(actual: any, expects: any, msg?: Message): void;
 }
 
 declare interface Equal {
-  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, message?: string): void;
-	<Actual extends Expects, Expects>(actual: Actual, expected: Expects, message?: string): void;
-	<Actual, Expects>(actual: Actual, expected: Expects, message?: string): boolean;
-	skip(actual: any, expected: any, message?: string): void;
+  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
+	<Actual extends Expects, Expects>(actual: Actual, expected: Expects, msg?: Message): void;
+	<Actual, Expects>(actual: Actual, expected: Expects, msg?: Message): boolean;
 }
 
-export type Message = string | Error;
 export const equal: Equal;
 export const is: Is;
 export function ok(actual: any, msg?: Message): asserts actual;

--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -2,20 +2,9 @@ type Types = 'string' | 'number' | 'boolean' | 'object' | 'undefined' | 'functio
 
 export type Message = string | Error;
 
-declare interface Is {
-  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
-	not(actual: any, expects: any, msg?: Message): void;
-}
-
-declare interface Equal {
-  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
-	<Actual extends Expects, Expects>(actual: Actual, expected: Expects, msg?: Message): void;
-	<Actual, Expects>(actual: Actual, expected: Expects, msg?: Message): boolean;
-}
-
-export const equal: Equal;
-export const is: Is;
 export function ok(actual: any, msg?: Message): asserts actual;
+export function is<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
+export function equal<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
 export function type(actual: any, expects: Types, msg?: Message): void;
 export function instance(actual: any, expects: any, msg?: Message): void;
 export function snapshot(actual: string, expects: string, msg?: Message): void;
@@ -24,6 +13,10 @@ export function match(actual: string, expects: string | RegExp, msg?: Message): 
 export function throws(fn: Function, expects?: Message | RegExp | Function, msg?: Message): void;
 export function not(actual: any, msg?: Message): void;
 export function unreachable(msg?: Message): void;
+
+export namespace is {
+	function not(actual: any, expects: any, msg?: Message): void;
+}
 
 export namespace not {
 	function ok(actual: any, msg?: Message): void;

--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -4,6 +4,8 @@ export type Message = string | Error;
 export function ok(actual: any, msg?: Message): asserts actual;
 export function is<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
 export function equal<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
+export function equal<Actual extends Expects, Expects>(actual: Actual, expected: Expects, msg?: Message): void;
+export function equal<Actual, Expects>(actual: Actual, expected: Expects, msg?: Message): void;
 export function type(actual: any, expects: Types, msg?: Message): void;
 export function instance(actual: any, expects: any, msg?: Message): void;
 export function snapshot(actual: string, expects: string, msg?: Message): void;

--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -1,7 +1,6 @@
 type Types = 'string' | 'number' | 'boolean' | 'object' | 'undefined' | 'function';
 
 export type Message = string | Error;
-
 export function ok(actual: any, msg?: Message): asserts actual;
 export function is<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;
 export function equal<Actual, Expects extends Actual>(actual: Actual, expected: Expects, msg?: Message): void;

--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -1,9 +1,21 @@
 type Types = 'string' | 'number' | 'boolean' | 'object' | 'undefined' | 'function';
 
+declare interface Is {
+  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, message?: string): void;
+	not(actual: any, expects: any, msg?: Message): void;
+}
+
+declare interface Equal {
+  <Actual, Expects extends Actual>(actual: Actual, expected: Expects, message?: string): void;
+	<Actual extends Expects, Expects>(actual: Actual, expected: Expects, message?: string): void;
+	<Actual, Expects>(actual: Actual, expected: Expects, message?: string): boolean;
+	skip(actual: any, expected: any, message?: string): void;
+}
+
 export type Message = string | Error;
+export const equal: Equal;
+export const is: Is;
 export function ok(actual: any, msg?: Message): asserts actual;
-export function is(actual: any, expects: any, msg?: Message): void;
-export function equal(actual: any, expects: any, msg?: Message): void;
 export function type(actual: any, expects: Types, msg?: Message): void;
 export function instance(actual: any, expects: any, msg?: Message): void;
 export function snapshot(actual: string, expects: string, msg?: Message): void;
@@ -12,10 +24,6 @@ export function match(actual: string, expects: string | RegExp, msg?: Message): 
 export function throws(fn: Function, expects?: Message | RegExp | Function, msg?: Message): void;
 export function not(actual: any, msg?: Message): void;
 export function unreachable(msg?: Message): void;
-
-export namespace is {
-	function not(actual: any, expects: any, msg?: Message): void;
-}
 
 export namespace not {
 	function ok(actual: any, msg?: Message): void;


### PR DESCRIPTION
This changes will improve TypeScript support:

1. User will have autocomplete in tests:

![Captura desde 2023-09-06 15-12-54](https://github.com/lukeed/uvu/assets/19343/c11f5b83-6fb1-4663-b00f-b4dfd3012e55)


2. Refactoring will be a little easier since test will help you guide what types you need to update (refactoring will be a little faster).

![Captura desde 2023-09-06 15-13-18](https://github.com/lukeed/uvu/assets/19343/9e41342f-093b-4160-a2a5-e6c191541f7f)
